### PR TITLE
Adds support for IronMQ.

### DIFF
--- a/lib/backburner/configuration.rb
+++ b/lib/backburner/configuration.rb
@@ -10,6 +10,8 @@ module Backburner
     attr_accessor :default_queues     # default queues
     attr_accessor :logger             # logger
     attr_accessor :default_worker     # default worker class
+    attr_accessor :connection_type    # connection type class
+    attr_accessor :auth               # authentication info
 
     def initialize
       @beanstalk_url     = "beanstalk://localhost"
@@ -22,6 +24,8 @@ module Backburner
       @default_queues    = []
       @logger            = nil
       @default_worker    = Backburner::Workers::Simple
+      @connection_type   = Backburner::Connection
+      @auth              = nil
     end
   end # Configuration
 end # Backburner

--- a/lib/backburner/worker.rb
+++ b/lib/backburner/worker.rb
@@ -49,7 +49,12 @@ module Backburner
     # @example
     #   Backburner::Worker.connection # => <Beaneater::Pool>
     def self.connection
-      @connection ||= Connection.new(Backburner.configuration.beanstalk_url)
+      unless @connection
+        connection_klass = Backburner.configuration.connection_type
+        @connection = connection_klass.new(Backburner.configuration.beanstalk_url, 
+                                           :auth => Backburner.configuration.auth)
+      end
+      @connection
     end
 
     # List of tube names to be watched and processed

--- a/lib/backburner/workers/forking.rb
+++ b/lib/backburner/workers/forking.rb
@@ -29,7 +29,10 @@ module Backburner
       # Waits for a job, works the job, and exits
       def fork_one_job
         pid = Process.fork do
-          @connection = Connection.new(Backburner.configuration.beanstalk_url)
+          connection_klass = Backburner.configuration.connection_type
+          @connection = connection_klass.new(Backburner.configuration.beanstalk_url, 
+                                             :auth => Backburner.configuration.auth)
+          @connection
           work_one_job
           coolest_exit
         end

--- a/lib/backburner/workers/threads_on_fork.rb
+++ b/lib/backburner/workers/threads_on_fork.rb
@@ -216,7 +216,9 @@ module Backburner
         pid = Kernel.fork do
           self.class.is_child = true
           $0 = "[ThreadsOnFork worker] parent: #{Process.ppid}"
-          @connection = Connection.new(Backburner.configuration.beanstalk_url)
+          connection_klass = Backburner.configuration.connection_type
+          @connection = connection_klass.new(Backburner.configuration.beanstalk_url, 
+                                             :auth => Backburner.configuration.auth)
           blk.call
         end
         self.class.child_pids << pid

--- a/test/connection_test.rb
+++ b/test/connection_test.rb
@@ -49,3 +49,18 @@ describe "Backburner::Connection class" do
     end
   end # delegator
 end # Connection
+
+describe "Backburner::IronMQConnection class" do
+
+  it "should authenticate to the IronMQ server" do
+    transmitted_msgs = []
+    msg_handler = Proc.new{|outbound_str| transmitted_msgs << outbound_str }
+    replace_method(Beaneater::Pool, :transmit_to_all, msg_handler) do
+      auth = {:project_id => 'unknown_project_id', :token => 'unknown_token'}
+      @connection = Backburner::IronMQConnection.new("beanstalk://localhost", :auth => auth)
+    end
+    assert_equal transmitted_msgs[0], "put 0 0 0 38\r\n"
+    assert_equal transmitted_msgs[1], "oauth unknown_token unknown_project_id"
+  end
+
+end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -100,3 +100,14 @@ class MiniTest::Spec
     end
   end
 end # MiniTest::Spec
+
+def replace_method(klass, action, replacement = Proc.new(){})
+  method = klass.instance_method(action)
+  klass.send(:define_method, action, replacement)
+  begin
+    yield
+  ensure
+    klass.send(:remove_method, action)
+    klass.send(:define_method, action, method)
+  end
+end


### PR DESCRIPTION
- Added `connection_type` configuration method, allowing users to specify a `Backburner::Connection` subclass;
- added `auth` configuration method, providing generic auth options for a `Connection` subclass instance;
- modified `Connection` instantiation across the project to include `:auth` dictionary arg;
- added `IronMQConnection` class;
- added test to ensure `IronMQConnection` was authenticating properly.

Notes:

No testing is done to ensure that auth is successful; this is tricky with a `Pool`.
IronMQ does not support the following Beanstalkd commands: release, bury, touch, peek, peek-ready, peek-delayed, peek-buried, kick, list-tubes, list-tube-used, stats, stats-job, stats-tube, pause-tube, quit.

See http://dev.iron.io/mq/reference/beanstalk/ for more information.
