### PR TITLE
IronMQ fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -400,10 +400,11 @@ jobs processed by your beanstalk workers. An excellent addition to your Backburn
 
 As of Backburner 0.4.0, the project now has baked in support for [IronMQ](http://www.iron.io/mq) which means that beanstalkd and backburner
 can now be used on Heroku as well. Thanks to [@kenkeiter](https://github.com/kenkeiter) for submitting the pull request for this. To enable IronMQ support,
-simply add the following configuration:
+simply add the following configuration (Note that default_queues must be specified because IronMQ does not support the list-tubes command):
 
 ```ruby
 Backburner.configure do |config|
+  config.default_queues  = [ 'some_queue_name' ]
   config.connection_proc = lambda { |url, opts|
     auth = { :project_id => 'some_project_id', :token => 'some_token_id' }
     Backburner::IronMQConnection.new("beanstalk://mq-aws-us-east-1.iron.io", :auth => auth)

--- a/lib/backburner/connection.rb
+++ b/lib/backburner/connection.rb
@@ -14,6 +14,11 @@ module Backburner
       connect!
     end
 
+    # True if connected to IronMQ
+    def iron_mq?
+      false
+    end
+
     # Sets the delegator object to the underlying beaneater pool
     # self.put(...)
     def __getobj__
@@ -51,20 +56,23 @@ module Backburner
   end # Connection
 
   class IronMQConnection < Connection
-      protected
+    def iron_mq?
+      true
+    end
 
-      def connect!
-        unless @beanstalk
-          @beanstalk = Beaneater::Pool.new(beanstalk_addresses)
-          authenticate! if @opts[:auth]
-        end
-        @beanstalk
-      end
+    protected
 
-      def authenticate!
-        auth = "oauth #{@opts[:auth][:token]} #{@opts[:auth][:project_id]}"
-        @beanstalk.transmit_to_all("put 0 0 0 #{auth.length}\r\n")
-        @beanstalk.transmit_to_all(auth)
+    def connect!
+      unless @beanstalk
+        @beanstalk = Beaneater::Pool.new(beanstalk_addresses)
+        authenticate! if @opts[:auth]
       end
-    end # IronMQConnection
+      @beanstalk
+    end
+
+    def authenticate!
+      auth = "oauth #{@opts[:auth][:token]} #{@opts[:auth][:project_id]}"
+      @beanstalk.transmit_to_all("put 0 0 0 #{auth.length}\r\n#{auth}")
+    end
+  end # IronMQConnection
 end # Backburner

--- a/lib/backburner/job.rb
+++ b/lib/backburner/job.rb
@@ -39,13 +39,14 @@ module Backburner
     # @example
     #   @task.process
     #
-    def process
+    def process(skip_timeout = false)
       # Invoke before hook and stop if false
       res = job_class.invoke_hook_events(:before_perform, *args)
       return false unless res
       # Execute the job
       job_class.around_hook_events(:around_perform, *args) do
-        timeout_job_after(task.ttr - 1) { job_class.perform(*args) }
+        ttr = skip_timeout ? 0 : task.ttr - 1
+        timeout_job_after(ttr) { job_class.perform(*args) }
       end
       task.delete
       # Invoke after perform hook

--- a/lib/backburner/worker.rb
+++ b/lib/backburner/worker.rb
@@ -110,7 +110,7 @@ module Backburner
     def work_one_job
       job = Backburner::Job.new(self.connection.tubes.reserve)
       self.log_job_begin(job.name, job.args)
-      job.process
+      job.process(self.connection.iron_mq?)
       self.log_job_end(job.name)
     rescue Backburner::Job::JobFormatInvalid => e
       self.log_error self.exception_message(e)

--- a/test/connection_test.rb
+++ b/test/connection_test.rb
@@ -61,8 +61,7 @@ describe "Backburner::IronMQConnection class" do
       replace_method(Beaneater::Pool, :transmit_to_all, msg_handler) do
         @connection = Backburner.configuration.establish_connection
       end
-      assert_equal transmitted_msgs[0], "put 0 0 0 38\r\n"
-      assert_equal transmitted_msgs[1], "oauth unknown_token unknown_project_id"
+      assert_equal transmitted_msgs[0], "put 0 0 0 38\r\noauth unknown_token unknown_project_id"
     ensure # revert
       Backburner.configuration.connection_proc = lambda { |url, opts| Backburner::Connection.new(url, opts) }
     end


### PR DESCRIPTION
This fixes IronMQ auth and prevents using the `stats-job` command as it is not supported by IronMQ. There is still an issue with the worker because IronMQ will only wait for 60 seconds for a message to become available before returning a nil response instead of waiting indefinitely like beanstalkd. The nil response breaks processing in beaneater so I'm not sure how to deal with this.
