### PR TITLE
More graceful shutdown using Kernel.exit and rescuing SystemExit.

### DIFF
--- a/lib/backburner/worker.rb
+++ b/lib/backburner/worker.rb
@@ -44,7 +44,11 @@ module Backburner
     #   Backburner::Worker.start(["foo.tube.name"])
     #
     def self.start(tube_names=nil)
-      self.new(tube_names).start
+      begin
+        self.new(tube_names).start
+      rescue SystemExit
+        # do nothing
+      end
     end
 
     # Returns the worker connection.
@@ -109,7 +113,7 @@ module Backburner
     # Triggers this worker to shutdown
     def shutdown
       log_info 'Worker exiting...'
-      Kernel.exit!
+      Kernel.exit
     end
 
     # Processes tube_names given tube_names array.


### PR DESCRIPTION
Using `Kernel.exit!` causes a few unexpected behaviors. If you run `Backburner.work` from a rails console and then kill it with Ctrl+C, the console session shouldn't also be killed (you currently get booted back to the terminal). Also, if you wrap everything up with the popular daemons gem or role your own wrapper script, any `at_exit` hooks will not run, so tasks like pid file cleanup don't work. This changes to using `Kernel.exit` and rescues the ensuing `SystemExit` exception allowing the work loop to exit gracefully.
