### PR TITLE
added ability to set per-queue default ttr's

### DIFF
--- a/README.md
+++ b/README.md
@@ -149,6 +149,11 @@ class NewsletterJob
   def self.queue_priority
     1000 # most urgent priority is 0
   end
+
+  # optional, defaults to respond_timeout
+  def self.queue_respond_timeout
+    300 # number of seconds before job times out
+  end
 end
 ```
 
@@ -159,6 +164,7 @@ class NewsletterJob
   include Backburner::Queue
   queue "newsletter-sender"  # defaults to 'backburner-jobs' tube
   queue_priority 1000 # most urgent priority is 0
+  queue_respond_timeout 300 # number of seconds before job times out
 
   def self.perform(email, body)
     NewsletterMailer.deliver_text_to_email(email, body)
@@ -186,6 +192,7 @@ class User
   include Backburner::Performable
   queue "user-jobs"  # defaults to 'user'
   queue_priority 500 # most urgent priority is 0
+  queue_respond_timeout 300 # number of seconds before job times out
 
   def activate(device_id)
     @device = Device.find(device_id)

--- a/lib/backburner/helpers.rb
+++ b/lib/backburner/helpers.rb
@@ -116,5 +116,22 @@ module Backburner
       end
     end
 
+    # Resolves job respond timeout based on the value given. Can be integer, a class or nothing
+    #
+    # @example
+    #  resolve_respond_timeout(1000) => 1000
+    #  resolve_respond_timeout(FooBar) => <queue respond_timeout>
+    #  resolve_respond_timeout(nil) => <default respond_timeout>
+    #
+    def resolve_respond_timeout(ttr)
+      if ttr.respond_to?(:queue_respond_timeout)
+        resolve_respond_timeout(ttr.queue_respond_timeout)
+      elsif ttr.is_a?(Fixnum) # numerical
+        ttr
+      else # default
+        Backburner.configuration.respond_timeout
+      end
+    end
+
   end # Helpers
 end # Backburner

--- a/lib/backburner/queue.rb
+++ b/lib/backburner/queue.rb
@@ -33,6 +33,20 @@ module Backburner
           @queue_priority
         end
       end
+
+      # Returns or assigns queue respond_timeout for this job
+      #
+      # @example
+      #   queue_respond_timeout 120
+      #   @klass.queue_respond_timeout # => 120
+      #
+      def queue_respond_timeout(ttr=nil)
+        if ttr
+          @queue_respond_timeout = ttr
+        else # accessor
+          @queue_respond_timeout
+        end
+      end
     end # ClassMethods
   end # Queue
 end # Backburner

--- a/lib/backburner/worker.rb
+++ b/lib/backburner/worker.rb
@@ -26,7 +26,7 @@ module Backburner
     def self.enqueue(job_class, args=[], opts={})
       pri   = resolve_priority(opts[:pri] || job_class)
       delay = [0, opts[:delay].to_i].max
-      ttr   = opts[:ttr] || Backburner.configuration.respond_timeout
+      ttr   = resolve_respond_timeout(opts[:ttr] || job_class)
       res = Backburner::Hooks.invoke_hook_events(job_class, :before_enqueue, *args)
       return false unless res # stop if hook is false
       data = { :class => job_class.name, :args => args }

--- a/test/fixtures/test_jobs.rb
+++ b/test/fixtures/test_jobs.rb
@@ -9,6 +9,7 @@ end
 class TestJob
   include Backburner::Queue
   queue_priority :medium
+  queue_respond_timeout 300
   def self.perform(x, y); $worker_test_count += x + y; end
 end
 

--- a/test/queue_test.rb
+++ b/test/queue_test.rb
@@ -31,5 +31,12 @@ describe "Backburner::Queue module" do
       NestedDemo::TestJobB.queue_priority(1000)
       assert_equal 1000, NestedDemo::TestJobB.queue_priority
     end
-  end # queue
+  end # queue_priority
+
+  describe "for queue_respond_timeout assignment method" do
+    it "should allow queue respond_timeout to be assigned" do
+      NestedDemo::TestJobB.queue_respond_timeout(300)
+      assert_equal 300, NestedDemo::TestJobB.queue_respond_timeout
+    end
+  end # queue_respond_timeout
 end # Backburner::Queue

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -1,7 +1,7 @@
 require 'rubygems'
 require 'tempfile'
 require 'minitest/autorun'
-require 'mocha'
+require 'mocha/setup'
 $:.unshift File.expand_path("../../lib")
 require 'backburner'
 require File.expand_path('../helpers/templogger', __FILE__)


### PR DESCRIPTION
This works just like `Backburner::Queue.queue_priority` and allows setting a default ttr that is specific to a given performable class.

Also fixes a couple of issues with the tests...
- Resolve mocha deprecation warning
- Reset default configuration after helper tests
- Clear jobs from tubes before worker tests
