### PR TITLE
Use a timeout when looking for a job to reserve

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,6 +99,7 @@ Backburner.configure do |config|
   config.logger           = Logger.new(STDOUT)
   config.primary_queue    = "backburner-jobs"
   config.priority_labels  = { :custom => 50, :useless => 1000 }
+  config.reserve_timeout  = nil
 end
 ```
 
@@ -115,6 +116,7 @@ The key options available are:
 | `logger`          | Logger recorded to when backburner wants to report info or errors.   |
 | `primary_queue`   | Primary queue used for a job when an alternate queue is not given.   |
 | `priority_labels` | Hash of named priority definitions for your app.                     |
+| `reserve_timeout` | Duration to wait for work from a single server, or nil for forever.  |
 
 ## Breaking Changes
 

--- a/lib/backburner/configuration.rb
+++ b/lib/backburner/configuration.rb
@@ -14,6 +14,7 @@ module Backburner
     attr_accessor :default_worker     # default worker class
     attr_accessor :primary_queue      # the general queue
     attr_accessor :priority_labels    # priority labels
+    attr_accessor :reserve_timeout    # duration to wait to reserve on a single server
 
     def initialize
       @beanstalk_url     = "beanstalk://localhost"
@@ -28,6 +29,7 @@ module Backburner
       @default_worker    = Backburner::Workers::Simple
       @primary_queue     = "backburner-jobs"
       @priority_labels   = PRIORITY_LABELS
+      @reserve_timeout   = nil
     end
   end # Configuration
 end # Backburner

--- a/lib/backburner/worker.rb
+++ b/lib/backburner/worker.rb
@@ -138,7 +138,11 @@ module Backburner
     #
     def work_one_job(conn = nil)
       conn ||= self.connection
-      job = Backburner::Job.new(conn.tubes.reserve)
+      begin
+        job = Backburner::Job.new(conn.tubes.reserve(Backburner.configuration.reserve_timeout))
+      rescue Beaneater::TimedOutError => e
+        return
+      end
       self.log_job_begin(job.name, job.args)
       job.process
       self.log_job_end(job.name)


### PR DESCRIPTION
Allow setting a timeout for the reserve command when looking for new
jobs.  Helps reduce starvation/increase throughput on job consumption
when using multiple beanstalk servers that don't receive jobs at the
same rate.

The default value of nil for .reserve_timeout keeps the previous
behavior.
