### PR TITLE
Support ThreadsOnFork class settings for threads, garbage and priority limits

### DIFF
--- a/lib/backburner/cli.rb
+++ b/lib/backburner/cli.rb
@@ -17,7 +17,6 @@ module Backburner
       runner.execute do |opts|
         queues = (opts[:queues] ? opts[:queues].split(',') : nil) rescue nil
         load_enviroment(opts[:require])
-        p queues
         Backburner.work(queues)
       end
     end

--- a/lib/backburner/helpers.rb
+++ b/lib/backburner/helpers.rb
@@ -80,6 +80,7 @@ module Backburner
     # Expands a tube to include the prefix
     #
     # @example
+    #   expand_tube_name("foo_with_settings:3:100:6") # => <prefix>.foo_with_settings
     #   expand_tube_name("foo") # => <prefix>.foo
     #   expand_tube_name(FooJob) # => <prefix>.foo-job
     #
@@ -94,7 +95,7 @@ module Backburner
       else # turn into a string
         tube.to_s
       end
-      [prefix.gsub(/\.$/, ''), dasherize(queue_name).gsub(/^#{prefix}/, '')].join(".").gsub(/\.+/, '.')
+      [prefix.gsub(/\.$/, ''), dasherize(queue_name).gsub(/^#{prefix}/, '')].join(".").gsub(/\.+/, '.').split(':').first
     end
 
     # Resolves job priority based on the value given. Can be integer, a class or nothing

--- a/lib/backburner/queue.rb
+++ b/lib/backburner/queue.rb
@@ -47,6 +47,48 @@ module Backburner
           @queue_respond_timeout
         end
       end
+
+      # Returns or assigns queue parallel active jobs limit (only ThreadsOnFork Worker)
+      #
+      # @example
+      #   queue_jobs_limit 5
+      #   @klass.queue_jobs_limit # => 5
+      #
+      def queue_jobs_limit(limit=nil)
+        if limit
+          @queue_jobs_limit = limit
+        else #accessor
+          @queue_jobs_limit
+        end
+      end
+
+      # Returns or assigns queue jobs garbage limit (only ThreadsOnFork Worker)
+      #
+      # @example
+      #   queue_garbage_limit 1000
+      #   @klass.queue_garbage_limit # => 1000
+      #
+      def queue_garbage_limit(limit=nil)
+        if limit
+          @queue_garbage_limit = limit
+        else #accessor
+          @queue_garbage_limit
+        end
+      end
+
+      # Returns or assigns queue retry limit (only ThreadsOnFork Worker)
+      #
+      # @example
+      #   queue_retry_limit 6
+      #   @klass.queue_retry_limit # => 6
+      #
+      def queue_retry_limit(limit=nil)
+        if limit
+          @queue_retry_limit = limit
+        else #accessor
+          @queue_retry_limit
+        end
+      end
     end # ClassMethods
   end # Queue
 end # Backburner

--- a/lib/backburner/workers/threads_on_fork.rb
+++ b/lib/backburner/workers/threads_on_fork.rb
@@ -70,6 +70,7 @@ module Backburner
       def initialize(*args)
         @tubes_data = {}
         super
+        self.process_tube_options
       end
 
       # Process the special tube_names of ThreadsOnFork worker
@@ -101,11 +102,29 @@ module Backburner
         end
       end
 
+      # Process the tube settings
+      # This overrides @tubes_data set by process_tube_names method. So a tube has name 'super_job:5:20:10'
+      # and the tube class has setting queue_jobs_limit 10, the result limit will be 10
+      # If the tube is known by existing beanstalkd queue, but not by class - skip it
+      #
+      def process_tube_options
+        Backburner::Worker.known_queue_classes.each do |queue|
+          next if @tubes_data[expand_tube_name(queue)].nil?
+          queue_settings = {
+              :threads => queue.queue_jobs_limit,
+              :garbage => queue.queue_garbage_limit,
+              :retries => queue.queue_retry_limit
+          }
+          @tubes_data[expand_tube_name(queue)].merge!(queue_settings){|k, v1, v2| v2.nil? ? v1 : v2 }
+        end
+      end
+
       def prepare
         self.tube_names ||= Backburner.default_queues.any? ? Backburner.default_queues : all_existing_queues
         self.tube_names = Array(self.tube_names)
         tube_names.map! { |name| expand_tube_name(name)  }
-        log_info "Working #{tube_names.size} queues: [ #{tube_names.join(', ')} ]"
+        tube_display_names = tube_names.map{|name| "#{name}:#{@tubes_data[name].values}"}
+        log_info "Working #{tube_names.size} queues: [ #{tube_display_names.join(', ')} ]"
       end
 
       # For each tube we will call fork_and_watch to create the fork

--- a/test/fixtures/test_queue_settings.rb
+++ b/test/fixtures/test_queue_settings.rb
@@ -1,0 +1,14 @@
+class TestJobSettings
+  include Backburner::Queue
+  queue "job-settings:5:10:6"
+  def self.perform; end
+end
+
+class TestJobSettingsOverride
+  include Backburner::Queue
+  queue "job-settings-override:5:10:12"
+  queue_jobs_limit 10
+  queue_garbage_limit 1000
+  queue_retry_limit 2
+  def self.perform; end
+end


### PR DESCRIPTION
This pull request supports class specific settings for Backburner::Worker::ThreadsOnFork as follows:

``` Ruby
class SuperJob
  include Backburner::Queue
  queue "super-job:5:1000:10"
end
```

the queue super-job will have 5 threads, 1000 garbage limit and 10 retries limit

``` Ruby
class SuperJob
  include Backburner::Queue
  queue "super-job"
  queue_jobs_limit 2
  queue_garbage_limit  500
  queue_priority 6
end
```

the queue super-job will have 2 threads, 500 garbage limit and 6 retires limit.

Note: class specific settings (if not nil) override name specific settings.
