### PR TITLE
Fix possible queue name override by existing beanstalkd queue

### DIFF
--- a/lib/backburner/worker.rb
+++ b/lib/backburner/worker.rb
@@ -201,7 +201,7 @@ module Backburner
     def all_existing_queues
       known_queues    = Backburner::Worker.known_queue_classes.map(&:queue)
       existing_tubes  = self.connection.tubes.all.map(&:name).select { |tube| tube =~ /^#{queue_config.tube_namespace}/ }
-      known_queues + existing_tubes + [queue_config.primary_queue]
+      existing_tubes + known_queues + [queue_config.primary_queue]
     end
 
     # Returns a reference to the beanstalk connection


### PR DESCRIPTION
(cherry picked from commit 7b17b2f)
