### PR TITLE
log_job_begin/log_job_end taks job to allow more useful logging

### DIFF
--- a/lib/backburner/logger.rb
+++ b/lib/backburner/logger.rb
@@ -8,18 +8,18 @@ module Backburner
     end
 
     # Print out when a job is about to begin
-    def log_job_begin(name, args)
-      log_info "Work job #{name} with #{args.inspect}"
+    def log_job_begin(job)
+      log_info "Work job #{job.name} with #{job.args.inspect}"
       @job_started_at = Time.now
     end
 
     # Print out when a job completed
     # If message is nil, job is considered complete
-    def log_job_end(name, message = nil)
+    def log_job_end(job, message = nil)
       ellapsed = Time.now - job_started_at
       ms = (ellapsed.to_f * 1000).to_i
       action_word = message ? 'Finished' : 'Completed'
-      log_info("#{action_word} #{name} in #{ms}ms #{message}")
+      log_info("#{action_word} #{job.name} in #{ms}ms #{message}")
     end
 
     # Returns true if the job logging started

--- a/lib/backburner/worker.rb
+++ b/lib/backburner/worker.rb
@@ -129,9 +129,9 @@ module Backburner
       rescue Beaneater::TimedOutError => e
         return
       end
-      self.log_job_begin(job.name, job.args)
+      self.log_job_begin(job)
       job.process
-      self.log_job_end(job.name)
+      self.log_job_end(job)
     rescue Backburner::Job::JobFormatInvalid => e
       self.log_error self.exception_message(e)
     rescue => e # Error occurred processing job
@@ -141,10 +141,10 @@ module Backburner
       if num_retries < queue_config.max_job_retries # retry again
         delay = queue_config.retry_delay + num_retries ** 3
         job.release(:delay => delay)
-        self.log_job_end(job.name, "#{retry_status}, retrying in #{delay}s") if job_started_at
+        self.log_job_end(job, "#{retry_status}, retrying in #{delay}s") if job_started_at
       else # retries failed, bury
         job.bury
-        self.log_job_end(job.name, "#{retry_status}, burying") if job_started_at
+        self.log_job_end(job, "#{retry_status}, burying") if job_started_at
       end
       handle_error(e, job.name, job.args, job)
     end


### PR DESCRIPTION
Just pass the job object to logging functions so more complex logging can be done. Unfortunately this is not backwards compatible if users have overridden these methods. If thats a big problem let me know.
