### PR TITLE
Change Dante dependency to allow v0.2.0

### DIFF
--- a/backburner.gemspec
+++ b/backburner.gemspec
@@ -17,7 +17,7 @@ Gem::Specification.new do |s|
   s.license       = 'MIT'
 
   s.add_runtime_dependency 'beaneater', '~> 0.3.1'
-  s.add_runtime_dependency 'dante', '~> 0.1.5'
+  s.add_runtime_dependency 'dante', '> 0.1.5'
 
   s.add_development_dependency 'rake'
   s.add_development_dependency 'minitest', '3.2.0'


### PR DESCRIPTION
Changed Dante dependency from '~> 0.1.5' to '> 0.1.5' to resolve a conflict with another gem (Stripe Mocks). All tests still pass.

@professorplumb
