### PR TITLE
Added ability to handle all calls to an instance or class method asynchronously

### DIFF
--- a/lib/backburner/helpers.rb
+++ b/lib/backburner/helpers.rb
@@ -89,7 +89,8 @@ module Backburner
       queue_name = if tube.is_a?(String)
         tube
       elsif tube.respond_to?(:queue) # use queue name
-        tube.queue
+        queue = tube.queue
+        queue.is_a?(Proc) ? queue.call(tube) : queue
       elsif tube.is_a?(Class) # no queue name, use default
         queue_config.primary_queue # tube.name
       else # turn into a string
@@ -133,6 +134,8 @@ module Backburner
         Backburner.configuration.respond_timeout
       end
     end
+
+
 
   end # Helpers
 end # Backburner

--- a/lib/backburner/performable.rb
+++ b/lib/backburner/performable.rb
@@ -40,5 +40,41 @@ module Backburner
       end # perform
     end # ClassMethods
 
+
+    # Make all calls to an instance method asynchronous. The given opts will be passed
+    # to the async method.
+    # @example
+    #   Backburner::Performable.handle_asynchronously(MyObject, :long_task, queue: 'long-tasks')
+    # NB: The method called on the async proxy will be ""#{method}_without_async". This
+    # will also be what's given to the Worker.enqueue method so your workers need
+    # to know about that. It shouldn't be a problem unless the producer and consumer are
+    # from different codebases (or anywhere they don't both call the handle_asynchronously
+    # method when booting up)
+    def self.handle_asynchronously(klass, method, opts={})
+      _handle_asynchronously(klass, klass, method, opts)
+    end
+
+    # Make all calls to a class method asynchronous. The given opts will be passed
+    # to the async method. Please see the NB on #handle_asynchronously
+    def self.handle_static_asynchronously(klass, method, opts={})
+      _handle_asynchronously(klass, klass.singleton_class, method, opts)
+    end
+
+    def self._handle_asynchronously(klass, klass_eval_scope, method, opts={})
+      with_async_name    = :"#{method}_with_async"
+      without_async_name = :"#{method}_without_async"
+
+      klass.send(:include, Performable) unless included_modules.include?(Performable)
+      klass_eval_scope.class_eval do
+        define_method with_async_name do |*args|
+          async(opts).__send__ without_async_name, *args
+        end
+        alias_method without_async_name, method.to_sym
+        alias_method method.to_sym, with_async_name
+      end
+    end
+    private_class_method :_handle_asynchronously
+
+
   end # Performable
 end # Backburner

--- a/lib/backburner/queue.rb
+++ b/lib/backburner/queue.rb
@@ -22,7 +22,7 @@ module Backburner
         if name
           @queue_name = name
         else # accessor
-          @queue_name || Backburner.configuration.primary_queue
+          (@queue_name.is_a?(Proc) ? @queue_name.call(self) : @queue_name) || Backburner.configuration.primary_queue
         end
       end
 

--- a/lib/backburner/worker.rb
+++ b/lib/backburner/worker.rb
@@ -31,7 +31,8 @@ module Backburner
       return false unless res # stop if hook is false
       data = { :class => job_class.name, :args => args }
       retryable_command do
-        tube  = connection.tubes[expand_tube_name(opts[:queue]  || job_class)]
+        queue = opts[:queue] && (Proc === opts[:queue] ? opts[:queue].call(job_class) : opts[:queue])
+        tube  = connection.tubes[expand_tube_name(queue || job_class)]
         tube.put(data.to_json, :pri => pri, :delay => delay, :ttr => ttr)
       end
       Backburner::Hooks.invoke_hook_events(job_class, :after_enqueue, *args)

--- a/test/fixtures/test_jobs.rb
+++ b/test/fixtures/test_jobs.rb
@@ -31,3 +31,9 @@ class TestAsyncJob
   include Backburner::Performable
   def self.foo(x, y); $worker_test_count = x * y; end
 end
+
+class TestLambdaQueueJob
+  include Backburner::Queue
+  queue lambda { |klass| klass.calculated_queue_name }
+  def self.calculated_queue_name; 'lambda-queue' end
+end

--- a/test/helpers_test.rb
+++ b/test/helpers_test.rb
@@ -75,6 +75,11 @@ describe "Backburner::Helpers module" do
     it "supports class names" do
       assert_equal "test.foo.job.backburner-jobs", expand_tube_name(RuntimeError)
     end # class names
+
+    it "supports lambdas" do
+      test = stub(:queue => lambda { |job_class| "email/send_news" })
+      assert_equal "test.foo.job.email/send-news", expand_tube_name(test)
+    end # lambdas
   end # expand_tube_name
 
   describe "for resolve_priority method" do

--- a/test/performable_test.rb
+++ b/test/performable_test.rb
@@ -1,7 +1,6 @@
 require File.expand_path('../test_helper', __FILE__)
 
 class TestObj
-  include Backburner::Performable
   ID = 56
   def id; ID; end
   def self.find(id); TestObj.new if id == ID; end
@@ -9,30 +8,57 @@ class TestObj
   def self.bar(state, state2); "baz #{state} #{state2}"; end
 end
 
+class PerformableTestObj < TestObj
+  include Backburner::Performable
+end
+
+class AutomagicTestObj < TestObj
+  # Don't include Backburner::Performable because it should be automagically included
+  def qux(state, state2); "garply #{state} #{state2}" end
+  def self.garply(state, state2); "thud #{state} #{state2}" end
+end
+
+
 describe "Backburner::Performable module" do
   after { ENV["TEST"] = nil }
 
   describe "for async instance method" do
     it "should invoke worker enqueue" do
-      Backburner::Worker.expects(:enqueue).with(TestObj, [56, :foo, true, false], has_entries(:pri => 5000, :queue => "foo"))
-      TestObj.new.async(:pri => 5000, :queue => "foo").foo(true, false)
+      Backburner::Worker.expects(:enqueue).with(PerformableTestObj, [56, :foo, true, false], has_entries(:pri => 5000, :queue => "foo"))
+      PerformableTestObj.new.async(:pri => 5000, :queue => "foo").foo(true, false)
     end
   end # async instance
 
   describe "for async class method" do
     it "should invoke worker enqueue" do
-      Backburner::Worker.expects(:enqueue).with(TestObj, [nil, :bar, true, false], has_entries(:pri => 5000, :queue => "foo"))
-      TestObj.async(:pri => 5000, :queue => "foo").bar(true, false)
+      Backburner::Worker.expects(:enqueue).with(PerformableTestObj, [nil, :bar, true, false], has_entries(:pri => 5000, :queue => "foo"))
+      PerformableTestObj.async(:pri => 5000, :queue => "foo").bar(true, false)
     end
   end # async class
 
   describe "for perform class method" do
     it "should work for instance" do
-      assert_equal "bar true false", TestObj.perform(TestObj::ID, :foo, true, false)
+      assert_equal "bar true false", PerformableTestObj.perform(PerformableTestObj::ID, :foo, true, false)
     end # instance
 
     it "should work for class level" do
-      assert_equal "baz false true", TestObj.perform(nil, :bar, false, true)
+      assert_equal "baz false true", PerformableTestObj.perform(nil, :bar, false, true)
     end # class
   end # perform
+
+  describe "for handle_asynchronously class method" do
+    it "should automagically asynchronously proxy calls to the method" do
+      Backburner::Performable.handle_asynchronously(AutomagicTestObj, :qux, :pri => 5000, :queue => "qux")
+
+      Backburner::Worker.expects(:enqueue).with(AutomagicTestObj, [56, :qux_without_async, true, false], has_entries(:pri => 5000, :queue => "qux"))
+      AutomagicTestObj.new.qux(true, false)
+    end
+
+    it "should work for class methods, too" do
+      Backburner::Performable.handle_static_asynchronously(AutomagicTestObj, :garply, :pri => 5000, :queue => "garply")
+
+      Backburner::Worker.expects(:enqueue).with(AutomagicTestObj, [nil, :garply_without_async, true, false], has_entries(:pri => 5000, :queue => "garply"))
+      AutomagicTestObj.garply(true, false)
+    end
+  end
 end

--- a/test/queue_test.rb
+++ b/test/queue_test.rb
@@ -24,6 +24,11 @@ describe "Backburner::Queue module" do
       NestedDemo::TestJobB.queue("nested/job")
       assert_equal "nested/job", NestedDemo::TestJobB.queue
     end
+
+    it "should allow lambdas" do
+      NestedDemo::TestJobB.queue(lambda { |klass| klass.name })
+      assert_equal "NestedDemo::TestJobB", NestedDemo::TestJobB.queue
+    end
   end # queue
 
   describe "for queue_priority assignment method" do

--- a/test/worker_test.rb
+++ b/test/worker_test.rb
@@ -63,6 +63,14 @@ describe "Backburner::Worker module" do
       assert_equal 100, job.ttr
       assert_equal Backburner.configuration.default_priority, job.pri
     end # async
+
+    it "should support enqueueing job with lambda queue" do
+      expected_queue_name = TestLambdaQueueJob.calculated_queue_name
+      Backburner::Worker.enqueue TestLambdaQueueJob, [6, 7], :queue => lambda { |klass| klass.calculated_queue_name }
+      job, body = pop_one_job(expected_queue_name)
+      assert_equal "TestLambdaQueueJob", body["class"]
+      assert_equal [6, 7], body["args"]
+    end
   end # enqueue
 
   describe "for start class method" do

--- a/test/workers/forking_worker_test.rb
+++ b/test/workers/forking_worker_test.rb
@@ -54,7 +54,7 @@ describe "Backburner::Workers::Forking module" do
       out = capture_stdout { worker.prepare }
       assert_contains worker.tube_names, "demo.test.backburner-jobs"
       assert_contains @worker_class.connection.tubes.watched.map(&:name), "demo.test.backburner-jobs"
-      assert_match(/demo\.test\.test-job/, out)
+      assert_match(/demo\.test\.backburner-jobs/, out)
     end # all read
   end # prepare
 


### PR DESCRIPTION
Inspired by same functionality in Delayed::Job. It enables a developer to make async decisions later (and potentially only in particular environments):

```
class Example
  def id; 1 end
  def hard_task; "Seriously, it's hard" end
end

# In a config file:
Backburner::Performable.handle_asynchronously(Example, :hard_task, pri: 123, queue: 'hard-jobs')

# Elsewhere in the code:
Example.new.hard_task # => will now be handled asynchronously automatically
```

The same can be done for static methods using `Backburner::Performable.handle_static_asynchronously(Example, :a_static_method, {})`

One edge case: If the producer and consumer aren't configured the same way, then this'll break, because the aliased method chain is actually what's enqueued – eg. the method enqueued is actually `hard_task_without_async` in our example. This should be fine in the vast majority of use cases, but something to note nonetheless.