### PR TITLE
Allow lambdas to determine queue name

### DIFF
--- a/README.md
+++ b/README.md
@@ -186,6 +186,10 @@ Backburner.enqueue NewsletterJob, 'foo@admin.com', 'lorem ipsum...'
 to that object's `perform` method. The queue name used by default is `{namespace}.backburner-jobs`
 unless otherwise specified.
 
+You may also pass a lambda as the queue name and it will be evaluated when enqueuing a
+job (and passed the Job's class as an argument). This is especially useful when combined
+with "Simple Async Jobs" (see below).
+
 ### Simple Async Jobs ###
 
 In addition to defining custom jobs, a job can also be enqueued by invoking the `async` method on any object which
@@ -218,7 +222,17 @@ User.async(:pri => 100, :delay => 10.seconds).reset_password(@user.id)
 This automatically enqueues a job for that user record that will run `activate` with the specified argument.
 Note that you can set the queue name and queue priority at the class level and
 you are also able to pass `pri`, `ttr`, `delay` and `queue` directly as options into `async`.
-The queue name used by default is `{namespace}.backburner-jobs` if not otherwise specified.
+
+The queue name used by default is `{namespace}.backburner-jobs` if not otherwise
+specified.
+
+If a lambda is given for `queue`, then it will be called and given the
+_performable_ object's class as an argument:
+
+```ruby
+# Given the User class above
+User.async(:queue => lambda { |user_klass| ["queue1","queue2"].sample(1).first }).do_hard_work # would add the job to either queue1 or queue2 randomly
+```
 
 ### Working Jobs
 

--- a/lib/backburner/helpers.rb
+++ b/lib/backburner/helpers.rb
@@ -90,7 +90,10 @@ module Backburner
       queue_name = if tube.is_a?(String)
         tube
       elsif tube.respond_to?(:queue) # use queue name
-        tube.queue
+        queue = tube.queue
+        queue.is_a?(Proc) ? queue.call(tube) : queue
+      elsif tube.is_a?(Proc)
+        tube.call
       elsif tube.is_a?(Class) # no queue name, use default
         queue_config.primary_queue # tube.name
       else # turn into a string

--- a/lib/backburner/queue.rb
+++ b/lib/backburner/queue.rb
@@ -22,7 +22,7 @@ module Backburner
         if name
           @queue_name = name
         else # accessor
-          @queue_name || Backburner.configuration.primary_queue
+          (@queue_name.is_a?(Proc) ? @queue_name.call(self) : @queue_name) || Backburner.configuration.primary_queue
         end
       end
 

--- a/lib/backburner/worker.rb
+++ b/lib/backburner/worker.rb
@@ -31,7 +31,8 @@ module Backburner
       return false unless res # stop if hook is false
       data = { :class => job_class.name, :args => args }
       retryable_command do
-        tube  = connection.tubes[expand_tube_name(opts[:queue]  || job_class)]
+        queue = opts[:queue] && (Proc === opts[:queue] ? opts[:queue].call(job_class) : opts[:queue])
+        tube  = connection.tubes[expand_tube_name(queue || job_class)]
         tube.put(data.to_json, :pri => pri, :delay => delay, :ttr => ttr)
       end
       Backburner::Hooks.invoke_hook_events(job_class, :after_enqueue, *args)

--- a/test/fixtures/test_jobs.rb
+++ b/test/fixtures/test_jobs.rb
@@ -31,3 +31,9 @@ class TestAsyncJob
   include Backburner::Performable
   def self.foo(x, y); $worker_test_count = x * y; end
 end
+
+class TestLambdaQueueJob
+  include Backburner::Queue
+  queue lambda { |klass| klass.calculated_queue_name }
+  def self.calculated_queue_name; 'lambda-queue' end
+end

--- a/test/helpers_test.rb
+++ b/test/helpers_test.rb
@@ -75,6 +75,16 @@ describe "Backburner::Helpers module" do
     it "supports class names" do
       assert_equal "test.foo.job.backburner-jobs", expand_tube_name(RuntimeError)
     end # class names
+
+    it "supports lambda in queue object" do
+      test = stub(:queue => lambda { |job_class| "email/send_news" })
+      assert_equal "test.foo.job.email/send-news", expand_tube_name(test)
+    end # lambdas in queue object
+
+    it "supports lambdas" do
+      test = lambda { "email/send_news" }
+      assert_equal "test.foo.job.email/send-news", expand_tube_name(test)
+    end #lambdas
   end # expand_tube_name
 
   describe "for alternative namespace separator" do

--- a/test/queue_test.rb
+++ b/test/queue_test.rb
@@ -24,6 +24,11 @@ describe "Backburner::Queue module" do
       NestedDemo::TestJobB.queue("nested/job")
       assert_equal "nested/job", NestedDemo::TestJobB.queue
     end
+
+    it "should allow lambdas" do
+      NestedDemo::TestJobB.queue(lambda { |klass| klass.name })
+      assert_equal "NestedDemo::TestJobB", NestedDemo::TestJobB.queue
+    end
   end # queue
 
   describe "for queue_priority assignment method" do

--- a/test/worker_test.rb
+++ b/test/worker_test.rb
@@ -63,6 +63,14 @@ describe "Backburner::Worker module" do
       assert_equal 100, job.ttr
       assert_equal Backburner.configuration.default_priority, job.pri
     end # async
+
+    it "should support enqueueing job with lambda queue" do
+      expected_queue_name = TestLambdaQueueJob.calculated_queue_name
+      Backburner::Worker.enqueue TestLambdaQueueJob, [6, 7], :queue => lambda { |klass| klass.calculated_queue_name }
+      job, body = pop_one_job(expected_queue_name)
+      assert_equal "TestLambdaQueueJob", body["class"]
+      assert_equal [6, 7], body["args"]
+    end
   end # enqueue
 
   describe "for start class method" do


### PR DESCRIPTION
This changeset allows one-off or pre-configured usages of lambdas to determine the queue name. (I personally use this in Delayed::Job for different video rendering queues.)

A couple examples:

```ruby
# Pre-configured queue using lambdas
class Example
  include Backburner::Queue
  queue lambda { |klass| klass.get_queue_name }

  def self.get_queue_name; "#{name.downcase}-jobs" end
  
  def hard_task; "do some work" end
end

# One-off usage of lambas
Backburner::Worker.enqueue(Example, :hard_task, queue: lambda { |klass| klass.get_queue_name })
```