### PR TITLE
Added ability to handle all calls to an instance or class method asynchronously

### DIFF
--- a/lib/backburner/performable.rb
+++ b/lib/backburner/performable.rb
@@ -38,7 +38,58 @@ module Backburner
           send(method, *args)
         end
       end # perform
+
+      # Always handle an instance method asynchronously
+      # @example
+      #   User.handle_asynchronously :send_welcome_email, queue: 'send-mail', delay: 10
+      def handle_asynchronously(method, opts={})
+        Backburner::Performable.handle_asynchronously(self, method, opts)
+      end
+
+      # Always handle a class method asynchronously
+      # @example
+      #   User.handle_static_asynchronously :update_recent_visitors, ttr: 300
+      def handle_static_asynchronously(method, opts={})
+        Backburner::Performable.handle_static_asynchronously(self, method, opts)
+      end
     end # ClassMethods
+
+
+    # Make all calls to an instance method asynchronous. The given opts will be passed
+    # to the async method.
+    # @example
+    #   Backburner::Performable.handle_asynchronously(MyObject, :long_task, queue: 'long-tasks')
+    # NB: The method called on the async proxy will be ""#{method}_without_async". This
+    # will also be what's given to the Worker.enqueue method so your workers need
+    # to know about that. It shouldn't be a problem unless the producer and consumer are
+    # from different codebases (or anywhere they don't both call the handle_asynchronously
+    # method when booting up)
+    def self.handle_asynchronously(klass, method, opts={})
+      _handle_asynchronously(klass, klass, method, opts)
+    end
+
+    # Make all calls to a class method asynchronous. The given opts will be passed
+    # to the async method. Please see the NB on #handle_asynchronously
+    def self.handle_static_asynchronously(klass, method, opts={})
+      _handle_asynchronously(klass, klass.singleton_class, method, opts)
+    end
+
+    def self._handle_asynchronously(klass, klass_eval_scope, method, opts={})
+      aliased_method, punctuation = method.to_s.sub(/([?!=])$/, ''), $1
+      with_async_name    = :"#{aliased_method}_with_async#{punctuation}"
+      without_async_name = :"#{aliased_method}_without_async#{punctuation}"
+
+      klass.send(:include, Performable) unless included_modules.include?(Performable)
+      klass_eval_scope.class_eval do
+        define_method with_async_name do |*args|
+          async(opts).__send__ without_async_name, *args
+        end
+        alias_method without_async_name, method.to_sym
+        alias_method method.to_sym, with_async_name
+      end
+    end
+    private_class_method :_handle_asynchronously
+
 
   end # Performable
 end # Backburner

--- a/test/performable_test.rb
+++ b/test/performable_test.rb
@@ -1,7 +1,6 @@
 require File.expand_path('../test_helper', __FILE__)
 
 class TestObj
-  include Backburner::Performable
   ID = 56
   def id; ID; end
   def self.find(id); TestObj.new if id == ID; end
@@ -9,30 +8,81 @@ class TestObj
   def self.bar(state, state2); "baz #{state} #{state2}"; end
 end
 
+class PerformableTestObj < TestObj
+  include Backburner::Performable
+end
+
+class AutomagicTestObj < TestObj
+  # Don't include Backburner::Performable because it should be automagically included
+  def qux(state, state2); "garply #{state} #{state2}" end
+  def self.garply(state, state2); "thud #{state} #{state2}" end
+  def qux?; "garply!" end
+end
+
+class AsyncInstanceMethodsTestObj < PerformableTestObj; end
+class AsyncStaticMethodsTestObj < PerformableTestObj; end
+
+
+
 describe "Backburner::Performable module" do
   after { ENV["TEST"] = nil }
 
   describe "for async instance method" do
     it "should invoke worker enqueue" do
-      Backburner::Worker.expects(:enqueue).with(TestObj, [56, :foo, true, false], has_entries(:pri => 5000, :queue => "foo"))
-      TestObj.new.async(:pri => 5000, :queue => "foo").foo(true, false)
+      Backburner::Worker.expects(:enqueue).with(PerformableTestObj, [56, :foo, true, false], has_entries(:pri => 5000, :queue => "foo"))
+      PerformableTestObj.new.async(:pri => 5000, :queue => "foo").foo(true, false)
     end
   end # async instance
 
   describe "for async class method" do
     it "should invoke worker enqueue" do
-      Backburner::Worker.expects(:enqueue).with(TestObj, [nil, :bar, true, false], has_entries(:pri => 5000, :queue => "foo"))
-      TestObj.async(:pri => 5000, :queue => "foo").bar(true, false)
+      Backburner::Worker.expects(:enqueue).with(PerformableTestObj, [nil, :bar, true, false], has_entries(:pri => 5000, :queue => "foo"))
+      PerformableTestObj.async(:pri => 5000, :queue => "foo").bar(true, false)
     end
   end # async class
 
   describe "for perform class method" do
     it "should work for instance" do
-      assert_equal "bar true false", TestObj.perform(TestObj::ID, :foo, true, false)
+      assert_equal "bar true false", PerformableTestObj.perform(PerformableTestObj::ID, :foo, true, false)
     end # instance
 
     it "should work for class level" do
-      assert_equal "baz false true", TestObj.perform(nil, :bar, false, true)
+      assert_equal "baz false true", PerformableTestObj.perform(nil, :bar, false, true)
     end # class
   end # perform
+
+  describe "for handle_asynchronously class method" do
+    it "should automagically asynchronously proxy calls to the method" do
+      Backburner::Performable.handle_asynchronously(AutomagicTestObj, :qux, :pri => 5000, :queue => "qux")
+
+      Backburner::Worker.expects(:enqueue).with(AutomagicTestObj, [56, :qux_without_async, true, false], has_entries(:pri => 5000, :queue => "qux"))
+      AutomagicTestObj.new.qux(true, false)
+    end
+
+    it "should work for class methods, too" do
+      Backburner::Performable.handle_static_asynchronously(AutomagicTestObj, :garply, :pri => 5000, :queue => "garply")
+
+      Backburner::Worker.expects(:enqueue).with(AutomagicTestObj, [nil, :garply_without_async, true, false], has_entries(:pri => 5000, :queue => "garply"))
+      AutomagicTestObj.garply(true, false)
+    end
+
+    it "should correctly handle punctuation" do
+      Backburner::Performable.handle_asynchronously(AutomagicTestObj, :qux?)
+
+      Backburner::Worker.expects(:enqueue).with(AutomagicTestObj, [56, :qux_without_async?], {})
+      AutomagicTestObj.new.qux?
+    end
+
+    it "should be available for instance methods on any class that includes the Performable module" do
+      AsyncInstanceMethodsTestObj.handle_asynchronously :foo, pri: 5000, queue: 'qux'
+      Backburner::Worker.expects(:enqueue).with(AsyncInstanceMethodsTestObj, [56, :foo_without_async, true, false], has_entries(:pri => 5000, :queue => "qux"))
+      AsyncInstanceMethodsTestObj.new.foo(true, false)
+    end
+
+    it "should be available for class methods on any class that includes the Performable module" do
+      AsyncStaticMethodsTestObj.handle_static_asynchronously :bar, pri: 5000, queue: 'garply'
+      Backburner::Worker.expects(:enqueue).with(AsyncStaticMethodsTestObj, [nil, :bar_without_async, true, false], has_entries(:pri => 5000, :queue => "garply"))
+      AsyncStaticMethodsTestObj.bar(true, false)
+    end
+  end
 end


### PR DESCRIPTION
Allows the developer to configure async usage separately from their code. This is especially useful when you only want asynchronous behavior in a particular environment. Inspired heavily by the same concept in Delayed::Job

Example:
```ruby
class Example
  def id: 1 end
  def hard_task; "…work…" end
end

# In a production config, perhaps:
Backburner::Performable.handle_asynchronously(Example, :hard_task)

# Now, this will use #async automagically:
Example.new.hard_task
```

There's also a way to handle class methods:
```ruby
class Example
  def self.hard_task; "…work…" end
end

# Elsewhere:
Backburner::Performable.handle_static_asynchronously(Example, :hard_task)

# It now uses #async
Example.hard_task
```

NB: If the producer and consumer are not configured the same way – eg. the producer uses `#handle_asynchronously` in its setup but the consumer doesn't – then the consumer will need to know that the method stored in beanstalkd has a suffix of "_without_async". (In the first example above, Backburner will actually store the method name as `:hard_task_without_async`.) This seems like a rare edge case, but it's imaginable.