### PR TITLE
Allow the calculation of delays to be configurable

### DIFF
--- a/lib/backburner/configuration.rb
+++ b/lib/backburner/configuration.rb
@@ -9,7 +9,8 @@ module Backburner
     attr_accessor :respond_timeout     # default job timeout
     attr_accessor :on_error            # error handler
     attr_accessor :max_job_retries     # max job retries
-    attr_accessor :retry_delay         # retry delay in seconds
+    attr_accessor :retry_delay         # (minimum) retry delay in seconds
+    attr_accessor :retry_delay_proc    # proc to calculate delay (and allow for back-off)
     attr_accessor :default_queues      # default queues
     attr_accessor :logger              # logger
     attr_accessor :default_worker      # default worker class
@@ -26,6 +27,7 @@ module Backburner
       @on_error            = nil
       @max_job_retries     = 0
       @retry_delay         = 5
+      @retry_delay_proc    = lambda { |min_retry_delay, num_retries| min_retry_delay + (num_retries ** 3) }
       @default_queues      = []
       @logger              = nil
       @default_worker      = Backburner::Workers::Simple

--- a/lib/backburner/worker.rb
+++ b/lib/backburner/worker.rb
@@ -139,7 +139,7 @@ module Backburner
       num_retries = job.stats.releases
       retry_status = "failed: attempt #{num_retries+1} of #{queue_config.max_job_retries+1}"
       if num_retries < queue_config.max_job_retries # retry again
-        delay = queue_config.retry_delay + num_retries ** 3
+        delay = queue_config.retry_delay_proc.call(queue_config.retry_delay, num_retries) rescue queue_config.retry_delay
         job.retry(num_retries + 1, delay)
         self.log_job_end(job.name, "#{retry_status}, retrying in #{delay}s") if job_started_at
       else # retries failed, bury

--- a/test/fixtures/test_jobs.rb
+++ b/test/fixtures/test_jobs.rb
@@ -27,6 +27,15 @@ class TestRetryJob
   end
 end
 
+class TestConfigurableRetryJob
+  include Backburner::Queue
+  def self.perform(retry_count)
+    $worker_test_count += 1
+    raise RuntimeError unless $worker_test_count > retry_count
+    $worker_success = true
+  end
+end
+
 class TestAsyncJob
   include Backburner::Performable
   def self.foo(x, y); $worker_test_count = x * y; end


### PR DESCRIPTION
I wanted to have exponential back-off in Backburner and looking through the code I found the hidden (and unconfigurable) exponential back-off used when calculating delay times (and I learned that `retry_delay` is *actually* just the *minimum* retry delay). 

So I made the retry delay calculation a configurable lambda. This also allows you to use just the configured `retry_delay` with `lambda { |retry_delay, _| retry_delay }`

It defaults to what the code does today and should be backwards compatible. It has test coverage (and I updated the README, too).