### PR TITLE
Option to reconfigure the namespace separator

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,35 +88,37 @@ Backburner is extremely simple to setup. Just configure basic settings for backb
 
 ```ruby
 Backburner.configure do |config|
-  config.beanstalk_url    = ["beanstalk://127.0.0.1", "..."]
-  config.tube_namespace   = "some.app.production"
-  config.on_error         = lambda { |e| puts e }
-  config.max_job_retries  = 3 # default 0 retries
-  config.retry_delay      = 2 # default 5 seconds
-  config.default_priority = 65536
-  config.respond_timeout  = 120
-  config.default_worker   = Backburner::Workers::Simple
-  config.logger           = Logger.new(STDOUT)
-  config.primary_queue    = "backburner-jobs"
-  config.priority_labels  = { :custom => 50, :useless => 1000 }
-  config.reserve_timeout  = nil
+  config.beanstalk_url       = ["beanstalk://127.0.0.1", "..."]
+  config.tube_namespace      = "some.app.production"
+  config.namespace_separator = "."
+  config.on_error            = lambda { |e| puts e }
+  config.max_job_retries     = 3 # default 0 retries
+  config.retry_delay         = 2 # default 5 seconds
+  config.default_priority    = 65536
+  config.respond_timeout     = 120
+  config.default_worker      = Backburner::Workers::Simple
+  config.logger              = Logger.new(STDOUT)
+  config.primary_queue       = "backburner-jobs"
+  config.priority_labels     = { :custom => 50, :useless => 1000 }
+  config.reserve_timeout     = nil
 end
 ```
 
 The key options available are:
 
-| Option            | Description                                                          |
-| ----------------- | -------------------------------                                      |
-| `beanstalk_url`   | Address such as 'beanstalk://127.0.0.1' or an array of addresses.    |
-| `tube_namespace`  | Prefix used for all tubes related to this backburner queue.          |
-| `on_error`        | Lambda invoked with the error whenever any job in the system fails.  |
-| `default_worker`  | Worker class that will be used if no other worker is specified.      |
-| `max_job_retries` | Integer defines how many times to retry a job before burying.        |
-| `retry_delay`     | Integer defines the base time to wait (in secs) between job retries. |
-| `logger`          | Logger recorded to when backburner wants to report info or errors.   |
-| `primary_queue`   | Primary queue used for a job when an alternate queue is not given.   |
-| `priority_labels` | Hash of named priority definitions for your app.                     |
-| `reserve_timeout` | Duration to wait for work from a single server, or nil for forever.  |
+| Option                | Description                                                          |
+| -----------------     | -------------------------------                                      |
+| `beanstalk_url`       | Address such as 'beanstalk://127.0.0.1' or an array of addresses.    |
+| `tube_namespace`      | Prefix used for all tubes related to this backburner queue.          |
+| `namespace_separator` | Separator used for namespace and queue name                      |
+| `on_error`            | Lambda invoked with the error whenever any job in the system fails.  |
+| `default_worker`      | Worker class that will be used if no other worker is specified.      |
+| `max_job_retries`     | Integer defines how many times to retry a job before burying.        |
+| `retry_delay`         | Integer defines the base time to wait (in secs) between job retries. |
+| `logger`              | Logger recorded to when backburner wants to report info or errors.   |
+| `primary_queue`       | Primary queue used for a job when an alternate queue is not given.   |
+| `priority_labels`     | Hash of named priority definitions for your app.                     |
+| `reserve_timeout`     | Duration to wait for work from a single server, or nil for forever.  |
 
 ## Breaking Changes
 

--- a/lib/backburner/configuration.rb
+++ b/lib/backburner/configuration.rb
@@ -4,7 +4,7 @@ module Backburner
 
     attr_accessor :beanstalk_url       # beanstalk url connection
     attr_accessor :tube_namespace      # namespace prefix for every queue
-    attr_accessor :namespace_separator # namespace separator
+    attr_reader   :namespace_separator # namespace separator
     attr_accessor :default_priority    # default job priority
     attr_accessor :respond_timeout     # default job timeout
     attr_accessor :on_error            # error handler
@@ -32,6 +32,11 @@ module Backburner
       @primary_queue       = "backburner-jobs"
       @priority_labels     = PRIORITY_LABELS
       @reserve_timeout     = nil
+    end
+
+    def namespace_separator=(val)
+      raise 'Namespace separator cannot used reserved queue configuration separator ":"' if val == ':'
+      @namespace_separator = val
     end
   end # Configuration
 end # Backburner

--- a/lib/backburner/configuration.rb
+++ b/lib/backburner/configuration.rb
@@ -2,34 +2,36 @@ module Backburner
   class Configuration
     PRIORITY_LABELS = { :high => 0, :medium => 100, :low => 200 }
 
-    attr_accessor :beanstalk_url      # beanstalk url connection
-    attr_accessor :tube_namespace     # namespace prefix for every queue
-    attr_accessor :default_priority   # default job priority
-    attr_accessor :respond_timeout    # default job timeout
-    attr_accessor :on_error           # error handler
-    attr_accessor :max_job_retries    # max job retries
-    attr_accessor :retry_delay        # retry delay in seconds
-    attr_accessor :default_queues     # default queues
-    attr_accessor :logger             # logger
-    attr_accessor :default_worker     # default worker class
-    attr_accessor :primary_queue      # the general queue
-    attr_accessor :priority_labels    # priority labels
-    attr_accessor :reserve_timeout    # duration to wait to reserve on a single server
+    attr_accessor :beanstalk_url       # beanstalk url connection
+    attr_accessor :tube_namespace      # namespace prefix for every queue
+    attr_accessor :namespace_separator # namespace separator
+    attr_accessor :default_priority    # default job priority
+    attr_accessor :respond_timeout     # default job timeout
+    attr_accessor :on_error            # error handler
+    attr_accessor :max_job_retries     # max job retries
+    attr_accessor :retry_delay         # retry delay in seconds
+    attr_accessor :default_queues      # default queues
+    attr_accessor :logger              # logger
+    attr_accessor :default_worker      # default worker class
+    attr_accessor :primary_queue       # the general queue
+    attr_accessor :priority_labels     # priority labels
+    attr_accessor :reserve_timeout     # duration to wait to reserve on a single server
 
     def initialize
-      @beanstalk_url     = "beanstalk://localhost"
-      @tube_namespace    = "backburner.worker.queue"
-      @default_priority  = 65536
-      @respond_timeout   = 120
-      @on_error          = nil
-      @max_job_retries   = 0
-      @retry_delay       = 5
-      @default_queues    = []
-      @logger            = nil
-      @default_worker    = Backburner::Workers::Simple
-      @primary_queue     = "backburner-jobs"
-      @priority_labels   = PRIORITY_LABELS
-      @reserve_timeout   = nil
+      @beanstalk_url       = "beanstalk://localhost"
+      @tube_namespace      = "backburner.worker.queue"
+      @namespace_separator = "."
+      @default_priority    = 65536
+      @respond_timeout     = 120
+      @on_error            = nil
+      @max_job_retries     = 0
+      @retry_delay         = 5
+      @default_queues      = []
+      @logger              = nil
+      @default_worker      = Backburner::Workers::Simple
+      @primary_queue       = "backburner-jobs"
+      @priority_labels     = PRIORITY_LABELS
+      @reserve_timeout     = nil
     end
   end # Configuration
 end # Backburner

--- a/lib/backburner/helpers.rb
+++ b/lib/backburner/helpers.rb
@@ -86,6 +86,7 @@ module Backburner
     #
     def expand_tube_name(tube)
       prefix = queue_config.tube_namespace
+      separator = queue_config.namespace_separator
       queue_name = if tube.is_a?(String)
         tube
       elsif tube.respond_to?(:queue) # use queue name
@@ -95,7 +96,7 @@ module Backburner
       else # turn into a string
         tube.to_s
       end
-      [prefix.gsub(/\.$/, ''), dasherize(queue_name).gsub(/^#{prefix}/, '')].join(".").gsub(/\.+/, '.').split(':').first
+      [prefix.gsub(/\.$/, ''), dasherize(queue_name).gsub(/^#{prefix}/, '')].join(separator).gsub(/#{Regexp::escape(separator)}+/, separator).split(':').first
     end
 
     # Resolves job priority based on the value given. Can be integer, a class or nothing

--- a/test/back_burner_test.rb
+++ b/test/back_burner_test.rb
@@ -66,6 +66,12 @@ describe "Backburner module" do
     it "remembers the namespace_separator" do
       assert_equal ".", Backburner.configuration.namespace_separator
     end
+
+    it "disallows a reserved separator" do
+      assert_raises RuntimeError do
+        Backburner.configuration.namespace_separator = ':'
+      end
+    end
   end # configuration
 
   describe "for default_queues" do

--- a/test/back_burner_test.rb
+++ b/test/back_burner_test.rb
@@ -62,6 +62,10 @@ describe "Backburner module" do
     it "remembers the tube_namespace" do
       assert_equal "demo.test", Backburner.configuration.tube_namespace
     end
+
+    it "remembers the namespace_separator" do
+      assert_equal ".", Backburner.configuration.namespace_separator
+    end
   end # configuration
 
   describe "for default_queues" do

--- a/test/helpers_test.rb
+++ b/test/helpers_test.rb
@@ -45,7 +45,7 @@ describe "Backburner::Helpers module" do
   end # exception_message
 
   describe "for queue_config" do
-    before { Backburner.expects(:configuration).returns(stub(:tube_namespace => "test.foo.job")) }
+    before { Backburner.expects(:configuration).returns(stub(:tube_namespace => "test.foo.job", :namespace_separator => '.')) }
 
     it "accesses correct value for namespace" do
       assert_equal "test.foo.job", queue_config.tube_namespace
@@ -53,7 +53,7 @@ describe "Backburner::Helpers module" do
   end # config
 
   describe "for expand_tube_name method" do
-    before { Backburner.stubs(:configuration).returns(stub(:tube_namespace => "test.foo.job.", :primary_queue => "backburner-jobs"))  }
+    before { Backburner.stubs(:configuration).returns(stub(:tube_namespace => "test.foo.job.", :namespace_separator => '.', :primary_queue => "backburner-jobs"))  }
 
     it "supports base strings" do
       assert_equal "test.foo.job.email/send-news", expand_tube_name("email/send_news")
@@ -76,6 +76,14 @@ describe "Backburner::Helpers module" do
       assert_equal "test.foo.job.backburner-jobs", expand_tube_name(RuntimeError)
     end # class names
   end # expand_tube_name
+
+  describe "for alternative namespace separator" do
+    before { Backburner.stubs(:configuration).returns(stub(:tube_namespace => "test", :namespace_separator => '-', :primary_queue => "backburner-jobs"))  }
+
+    it "uses alternative namespace separator" do
+      assert_equal "test-queue-name", expand_tube_name("queue_name")
+    end # simple string
+  end
 
   describe "for resolve_priority method" do
     before do


### PR DESCRIPTION
Added the option to reconfigure the namespace separator from '.' to something else.