### PR TITLE
Add hooks on retrying and burying

### DIFF
--- a/lib/backburner/worker.rb
+++ b/lib/backburner/worker.rb
@@ -140,7 +140,7 @@ module Backburner
       retry_status = "failed: attempt #{num_retries+1} of #{queue_config.max_job_retries+1}"
       if num_retries < queue_config.max_job_retries # retry again
         delay = queue_config.retry_delay + num_retries ** 3
-        job.release(:delay => delay)
+        job.retry(num_retries + 1, delay)
         self.log_job_end(job.name, "#{retry_status}, retrying in #{delay}s") if job_started_at
       else # retries failed, bury
         job.bury

--- a/test/fixtures/hooked.rb
+++ b/test/fixtures/hooked.rb
@@ -100,6 +100,14 @@ class HookedObjectSuccess
     puts "!!on_failure_foo!! #{ex.inspect} #{args.inspect}"
   end
 
+  def self.on_bury_foo(*args)
+    puts "!!on_bury_foo!! #{args.inspect}"
+  end
+
+  def self.on_retry_foo(retry_count, delay, *args)
+    puts "!!on_retry_foo!! #{retry_count} #{delay} #{args.inspect}"
+  end
+
   def self.foo(x)
     $hooked_fail_count += 1
     raise HookFailError, "Fail!" if $hooked_fail_count == 1

--- a/test/hooks_test.rb
+++ b/test/hooks_test.rb
@@ -69,6 +69,20 @@ describe "Backburner::Hooks module" do
         assert_match(/!!on_failure_foo!! RuntimeError \[10\]/, out)
       end
     end # on_failure
+
+    describe 'with on_retry' do
+      it "should support successful invocation" do
+        out = silenced { @hooks.invoke_hook_events(HookedObjectSuccess, :on_retry, 1, 0, 10) }
+        assert_match(/!!on_retry_foo!! 1 0 \[10\]/, out)
+      end
+    end
+
+    describe 'with on_bury' do
+      it "should support successful invocation" do
+        out = silenced { @hooks.invoke_hook_events(HookedObjectSuccess, :on_bury, 10) }
+        assert_match(/!!on_bury_foo!! \[10\]/, out)
+      end
+    end
   end # invoke_hook_events
 
   describe "for around_hook_events method" do

--- a/test/workers/simple_worker_test.rb
+++ b/test/workers/simple_worker_test.rb
@@ -188,6 +188,7 @@ describe "Backburner::Workers::Basic module" do
       assert_match(/!!BEGIN around_perform_bar!! \[nil, "foo", 5\]/, out)
       assert_match(/!!BEGIN around_perform_cat!! \[nil, "foo", 5\]/, out)
       assert_match(/!!on_failure_foo!!.*HookFailError/, out)
+      assert_match(/!!on_bury_foo!! \[nil, "foo", 5\]/, out)
       assert_match(/attempt 1 of 1, burying/, out)
     end # event hooks, no retry
 
@@ -211,6 +212,7 @@ describe "Backburner::Workers::Basic module" do
       assert_match(/!!BEGIN around_perform_cat!! \[nil, "foo", 5\]/, out)
       assert_match(/!!on_failure_foo!!.*HookFailError/, out)
       assert_match(/!!on_failure_foo!!.*retrying.*around_perform_bar.*around_perform_cat/m, out)
+      assert_match(/!!on_retry_foo!! 1 0 \[nil, "foo", 5\]/, out)
       assert_match(/attempt 1 of 2, retrying/, out)
       assert_match(/!!before_perform_foo!! \[nil, "foo", 5\]/, out)
       assert_match(/!!END around_perform_bar!! \[nil, "foo", 5\]/, out)


### PR DESCRIPTION
This satisfies #97 as well as adding hooks anytime the job is released for retry.

It adds hooks for `:on_retry` and `:on_bury`. `on_retry` will pass the retry count (inclusive of this attempt) and the delay as well as all of the rest of the job's args. `on_bury` passes the job's args as usual without anything extra.