### PR TITLE
Add support for custom serialization formats

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,6 +102,9 @@ Backburner.configure do |config|
   config.primary_queue       = "backburner-jobs"
   config.priority_labels     = { :custom => 50, :useless => 1000 }
   config.reserve_timeout     = nil
+  config.job_serializer_proc = lambda { |body| JSON.dump(body) }
+  config.job_parser_proc     = lambda { |body| JSON.parse(body) }
+
 end
 ```
 
@@ -123,6 +126,8 @@ The key options available are:
 | `primary_queue`       | Primary queue used for a job when an alternate queue is not given.   |
 | `priority_labels`     | Hash of named priority definitions for your app.                     |
 | `reserve_timeout`     | Duration to wait for work from a single server, or nil for forever.  |
+| `job_serializer_proc` | Lambda serializes a job body to a string to write to the task        |
+| `job_parser_proc`     | Lambda parses a task body string to a hash                           |
 
 ## Breaking Changes
 

--- a/lib/backburner/configuration.rb
+++ b/lib/backburner/configuration.rb
@@ -17,6 +17,8 @@ module Backburner
     attr_accessor :primary_queue       # the general queue
     attr_accessor :priority_labels     # priority labels
     attr_accessor :reserve_timeout     # duration to wait to reserve on a single server
+    attr_accessor :job_serializer_proc # proc to write the job body to a string
+    attr_accessor :job_parser_proc     # proc to parse a job body from a string
 
     def initialize
       @beanstalk_url       = "beanstalk://127.0.0.1"
@@ -34,6 +36,8 @@ module Backburner
       @primary_queue       = "backburner-jobs"
       @priority_labels     = PRIORITY_LABELS
       @reserve_timeout     = nil
+      @job_serializer_proc = lambda { |body| body.to_json }
+      @job_parser_proc     = lambda { |body| JSON.parse(body) }
     end
 
     def namespace_separator=(val)

--- a/lib/backburner/job.rb
+++ b/lib/backburner/job.rb
@@ -22,7 +22,8 @@ module Backburner
       @hooks = Backburner::Hooks
       @task = task
       @body = task.body.is_a?(Hash) ? task.body : Backburner.configuration.job_parser_proc.call(task.body)
-      @name, @args = body["class"], body["args"]
+      @name = body["class"] || body[:class]
+      @args = body["args"] || body[:args]
     rescue => ex # Job was not valid format
       self.bury
       raise JobFormatInvalid, "Job body could not be parsed: #{ex.inspect}"

--- a/lib/backburner/job.rb
+++ b/lib/backburner/job.rb
@@ -21,7 +21,7 @@ module Backburner
     def initialize(task)
       @hooks = Backburner::Hooks
       @task = task
-      @body = task.body.is_a?(Hash) ? task.body : JSON.parse(task.body)
+      @body = task.body.is_a?(Hash) ? task.body : Backburner.configuration.job_parser_proc.call(task.body)
       @name, @args = body["class"], body["args"]
     rescue => ex # Job was not valid format
       self.bury

--- a/lib/backburner/worker.rb
+++ b/lib/backburner/worker.rb
@@ -39,7 +39,8 @@ module Backburner
         connection = Backburner::Connection.new(Backburner.configuration.beanstalk_url)
         connection.retryable do
           tube = connection.tubes[expand_tube_name(queue || job_class)]
-          response = tube.put(data.to_json, :pri => pri, :delay => delay, :ttr => ttr)
+          serialized_data = Backburner.configuration.job_serializer_proc.call(data)
+          response = tube.put(serialized_data, :pri => pri, :delay => delay, :ttr => ttr)
         end
         return nil unless Backburner::Hooks.invoke_hook_events(job_class, :after_enqueue, *args)
       ensure

--- a/test/job_test.rb
+++ b/test/job_test.rb
@@ -15,16 +15,29 @@ describe "Backburner::Job module" do
   describe "for initialize" do
     describe "with hash" do
       before do
-        @task_body =  { "class" => "NewsletterSender", "args" => ["foo@bar.com", "bar@foo.com"] }
-        @task = stub(:body => @task_body, :ttr => 120, :delete => true, :bury => true)
+        @task = stub(:body => task_body, :ttr => 120, :delete => true, :bury => true)
       end
 
-      it "should create job with correct task data" do
-        @job = Backburner::Job.new(@task)
-        assert_equal @task, @job.task
-        assert_equal ["class", "args"], @job.body.keys
-        assert_equal @task_body["class"], @job.name
-        assert_equal @task_body["args"], @job.args
+      describe "with string keys" do
+        let(:task_body) { { "class" => "NewsletterSender", "args" => ["foo@bar.com", "bar@foo.com"] } }
+        it "should create job with correct task data" do
+          @job = Backburner::Job.new(@task)
+          assert_equal @task, @job.task
+          assert_equal ["class", "args"], @job.body.keys
+          assert_equal task_body["class"], @job.name
+          assert_equal task_body["args"], @job.args
+        end
+      end
+
+      describe "with symbol keys" do
+        let(:task_body) { { :class => "NewsletterSender", :args => ["foo@bar.com", "bar@foo.com"] } }
+        it "should create job with correct task data" do
+          @job = Backburner::Job.new(@task)
+          assert_equal @task, @job.task
+          assert_equal [:class, :args], @job.body.keys
+          assert_equal task_body[:class], @job.name
+          assert_equal task_body[:args], @job.args
+        end
       end
     end # with hash
 

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -92,12 +92,12 @@ class MiniTest::Spec
   end
 
   # pop_one_job(tube_name)
-  def pop_one_job(tube_name=Backburner.configuration.primary_queue, &block)
+  def pop_one_job(tube_name=Backburner.configuration.primary_queue)
     tube_name  = [Backburner.configuration.tube_namespace, tube_name].join(".")
     connection = beanstalk_connection
     connection.tubes.watch!(tube_name)
     silenced(3) { @res = connection.tubes.reserve }
-    yield @res, JSON.parse(@res.body)
+    yield @res, Backburner.configuration.job_parser_proc.call(@res.body)
   ensure
     connection.close if connection
   end


### PR DESCRIPTION
By supporting configurable serialization and deserialization procs, we can allow users to format job bodies as they wish.
Defaults to JSON for compatibility.