### PR TITLE
Threaded worker graceful shutdown

### DIFF
--- a/lib/backburner/logger.rb
+++ b/lib/backburner/logger.rb
@@ -10,7 +10,7 @@ module Backburner
     # Print out when a job is about to begin
     def log_job_begin(name, args)
       log_info "Work job #{name} with #{args.inspect}"
-      @job_started_at = Time.now
+      Thread.current[:job_started_at] = Time.now
     end
 
     # Print out when a job completed
@@ -24,7 +24,7 @@ module Backburner
 
     # Returns true if the job logging started
     def job_started_at
-      @job_started_at
+      Thread.current[:job_started_at]
     end
 
     # Print a message to stdout

--- a/test/fixtures/test_jobs.rb
+++ b/test/fixtures/test_jobs.rb
@@ -13,6 +13,24 @@ class TestJob
   def self.perform(x, y); $worker_test_count += x + y; end
 end
 
+class TestSlowJob
+  include Backburner::Queue
+  queue_priority :medium
+  queue_respond_timeout 300
+  def self.perform(x, y); sleep 1; $worker_test_count += x + y; end
+end
+
+class TestStuckJob
+  include Backburner::Queue
+  queue_priority :medium
+  queue_respond_timeout 300
+  def self.perform(_x, _y)
+    loop do
+      sleep 0.5
+    end
+  end
+end
+
 class TestFailJob
   include Backburner::Queue
   def self.perform(x, y); raise RuntimeError; end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -6,7 +6,7 @@ begin
 rescue LoadError
   require 'mocha'
 end
-$:.unshift File.expand_path("../../lib")
+$LOAD_PATH.unshift File.expand_path("lib")
 require 'backburner'
 require File.expand_path('../helpers/templogger', __FILE__)
 


### PR DESCRIPTION
The current behaviour of the threaded worker is to immediately kill all the threadpools and force the reserved jobs to only reappear on the ready queues when they reach TTL. 

This PR switches the approach to call `#shutdown` on each pool to prevent workers from reserving new jobs. Any workers already performing a blocking reserve (ie there's nothing in the tube) will mean the worker process won't die until the `shutdown_timeout` it reached (defaults to 10 seconds).
To make this work I had to switch up the signal handling for the threaded worker to use a self-pipe approach to escape the trap context (the same approach as sidekiq).
The graceful shutdown timeout period can be ended early by sending another TERM/INT signal to the process.

Also included in this PR are fixes to the threaded worker logging (timing code was not threadsafe) and a change to the test_helper load path (on my machine it was the installed gem that was being tested, rather than the repo). Let me know if you would rather I pull these out into their own PRs.