### PR TITLE
Retry jobs without logging an error

### DIFF
--- a/README.md
+++ b/README.md
@@ -513,6 +513,9 @@ end
 
 Now all backburner queue errors will appear on airbrake for deeper inspection.
 
+If you wish to retry a job without logging an error (for example when handling transient issues in a cloud or service oriented environment), 
+simply raise a `Backburner::Job::RetryJob` error.
+
 ### Logging
 
 Logging in backburner is rather simple. When a job is run, the log records that. When a job

--- a/lib/backburner/job.rb
+++ b/lib/backburner/job.rb
@@ -7,6 +7,7 @@ module Backburner
     class JobTimeout < RuntimeError; end
     class JobNotFound < RuntimeError; end
     class JobFormatInvalid < RuntimeError; end
+    class RetryJob < RuntimeError; end
 
     attr_accessor :task, :body, :name, :args
 

--- a/lib/backburner/worker.rb
+++ b/lib/backburner/worker.rb
@@ -140,7 +140,7 @@ module Backburner
     rescue Backburner::Job::JobFormatInvalid => e
       self.log_error self.exception_message(e)
     rescue => e # Error occurred processing job
-      self.log_error self.exception_message(e)
+      self.log_error self.exception_message(e) unless e.is_a?(Backburner::Job::RetryJob)
 
       unless job
         self.log_error "Error occurred before we were able to assign a job. Giving up without retrying!"


### PR DESCRIPTION
Sometimes jobs have known/expected failure scenarios. For example a data race in a dependency or some kind of CAS system where many writers are trying to update a record.
This PR adds a new Error type: `Backburner::Job::RetryJob` that is not logged by the worker when raised inside a job.