### PR TITLE
Allow per queue overrides of retry settings

### DIFF
--- a/README.md
+++ b/README.md
@@ -163,9 +163,24 @@ class NewsletterJob
     1000 # most urgent priority is 0
   end
 
-  # optional, defaults to respond_timeout
+  # optional, defaults to respond_timeout in config
   def self.queue_respond_timeout
     300 # number of seconds before job times out, 0 to avoid timeout. NB: A timeout of 1 second will likely lead to race conditions between Backburner and beanstalkd and should be avoided
+  end
+
+  # optional, defaults to retry_delay_proc in config
+  def self.queue_retry_delay_proc
+    lambda { |min_retry_delay, num_retries| min_retry_delay + (num_retries ** 5) }
+  end
+
+  # optional, defaults to retry_delay in config
+  def self.queue_retry_delay
+    5
+  end
+
+  # optional, defaults to max_job_retries in config
+  def self.queue_max_job_retries
+    5
   end
 end
 ```

--- a/lib/backburner/helpers.rb
+++ b/lib/backburner/helpers.rb
@@ -138,12 +138,29 @@ module Backburner
       end
     end
 
+    # Resolves max retries based on the value given. Can be integer, a class or nothing
+    #
+    # @example
+    #  resolve_max_job_retries(5) => 5
+    #  resolve_max_job_retries(FooBar) => <queue max_job_retries>
+    #  resolve_max_job_retries(nil) => <default max_job_retries>
+    #
+    def resolve_max_job_retries(retries)
+      if retries.respond_to?(:queue_max_job_retries)
+        resolve_max_job_retries(retries.queue_max_job_retries)
+      elsif retries.is_a?(Integer) # numerical
+        retries
+      else # default
+        Backburner.configuration.max_job_retries
+      end
+    end
+
     # Resolves retry delay based on the value given. Can be integer, a class or nothing
     #
     # @example
     #  resolve_retry_delay(5) => 5
-    #  resolve_retry_delay(FooBar) => <queue respond_timeout>
-    #  resolve_retry_delay(nil) => <default respond_timeout>
+    #  resolve_retry_delay(FooBar) => <queue retry_delay>
+    #  resolve_retry_delay(nil) => <default retry_delay>
     #
     def resolve_retry_delay(delay)
       if delay.respond_to?(:queue_retry_delay)
@@ -152,6 +169,23 @@ module Backburner
         delay
       else # default
         Backburner.configuration.retry_delay
+      end
+    end
+
+    # Resolves retry delay proc based on the value given. Can be proc, a class or nothing
+    #
+    # @example
+    #  resolve_retry_delay_proc(proc) => proc
+    #  resolve_retry_delay_proc(FooBar) => <queue retry_delay_proc>
+    #  resolve_retry_delay_proc(nil) => <default retry_delay_proc>
+    #
+    def resolve_retry_delay_proc(proc)
+      if proc.respond_to?(:queue_retry_delay_proc)
+        resolve_retry_delay_proc(proc.queue_retry_delay_proc)
+      elsif proc.is_a?(Proc)
+        proc
+      else # default
+        Backburner.configuration.retry_delay_proc
       end
     end
 

--- a/lib/backburner/helpers.rb
+++ b/lib/backburner/helpers.rb
@@ -138,5 +138,22 @@ module Backburner
       end
     end
 
+    # Resolves retry delay based on the value given. Can be integer, a class or nothing
+    #
+    # @example
+    #  resolve_retry_delay(5) => 5
+    #  resolve_retry_delay(FooBar) => <queue respond_timeout>
+    #  resolve_retry_delay(nil) => <default respond_timeout>
+    #
+    def resolve_retry_delay(delay)
+      if delay.respond_to?(:queue_retry_delay)
+        resolve_retry_delay(delay.queue_retry_delay)
+      elsif delay.is_a?(Integer) # numerical
+        delay
+      else # default
+        Backburner.configuration.retry_delay
+      end
+    end
+
   end # Helpers
 end # Backburner

--- a/lib/backburner/job.rb
+++ b/lib/backburner/job.rb
@@ -73,8 +73,6 @@ module Backburner
       task.release(delay: delay)
     end
 
-    protected
-
     # Returns the class for the job handler
     #
     # @example
@@ -85,6 +83,8 @@ module Backburner
       raise(JobNotFound, self.name) unless handler
       handler
     end
+
+    protected
 
     # Attempts to return a constantized job name, otherwise reverts to the name string
     #

--- a/lib/backburner/queue.rb
+++ b/lib/backburner/queue.rb
@@ -4,6 +4,7 @@ module Backburner
       base.instance_variable_set(:@queue_name, nil)
       base.instance_variable_set(:@queue_priority, nil)
       base.instance_variable_set(:@queue_respond_timeout, nil)
+      base.instance_variable_set(:@queue_retry_delay, nil)
       base.instance_variable_set(:@queue_jobs_limit, nil)
       base.instance_variable_set(:@queue_garbage_limit, nil)
       base.instance_variable_set(:@queue_retry_limit, nil)
@@ -51,6 +52,20 @@ module Backburner
           @queue_respond_timeout = ttr
         else # accessor
           @queue_respond_timeout
+        end
+      end
+
+      # Returns or assigns queue retry_delay for this job
+      #
+      # @example
+      #   queue_retry_delay 120
+      #   @klass.queue_retry_delay # => 120
+      #
+      def queue_retry_delay(delay=nil)
+        if delay
+          @queue_retry_delay = delay
+        else # accessor
+          @queue_retry_delay
         end
       end
 

--- a/lib/backburner/queue.rb
+++ b/lib/backburner/queue.rb
@@ -4,7 +4,9 @@ module Backburner
       base.instance_variable_set(:@queue_name, nil)
       base.instance_variable_set(:@queue_priority, nil)
       base.instance_variable_set(:@queue_respond_timeout, nil)
+      base.instance_variable_set(:@queue_max_job_retries, nil)
       base.instance_variable_set(:@queue_retry_delay, nil)
+      base.instance_variable_set(:@queue_retry_delay_proc, nil)
       base.instance_variable_set(:@queue_jobs_limit, nil)
       base.instance_variable_set(:@queue_garbage_limit, nil)
       base.instance_variable_set(:@queue_retry_limit, nil)
@@ -55,6 +57,20 @@ module Backburner
         end
       end
 
+      # Returns or assigns queue max_job_retries for this job
+      #
+      # @example
+      #   queue_max_job_retries 120
+      #   @klass.queue_max_job_retries # => 120
+      #
+      def queue_max_job_retries(delay=nil)
+        if delay
+          @queue_max_job_retries = delay
+        else # accessor
+          @queue_max_job_retries
+        end
+      end
+
       # Returns or assigns queue retry_delay for this job
       #
       # @example
@@ -66,6 +82,20 @@ module Backburner
           @queue_retry_delay = delay
         else # accessor
           @queue_retry_delay
+        end
+      end
+
+      # Returns or assigns queue retry_delay_proc for this job
+      #
+      # @example
+      #   queue_retry_delay_proc lambda { |min_retry_delay, num_retries| min_retry_delay + (num_retries ** 2) }
+      #   @klass.queue_retry_delay_proc # => lambda { |min_retry_delay, num_retries| min_retry_delay + (num_retries ** 2) }
+      #
+      def queue_retry_delay_proc(proc=nil)
+        if proc
+          @queue_retry_delay_proc = proc
+        else # accessor
+          @queue_retry_delay_proc
         end
       end
 

--- a/lib/backburner/worker.rb
+++ b/lib/backburner/worker.rb
@@ -152,7 +152,8 @@ module Backburner
       num_retries = job.stats.releases
       retry_status = "failed: attempt #{num_retries+1} of #{queue_config.max_job_retries+1}"
       if num_retries < queue_config.max_job_retries # retry again
-        delay = queue_config.retry_delay_proc.call(queue_config.retry_delay, num_retries) rescue queue_config.retry_delay
+        retry_delay = resolve_retry_delay(job.job_class)
+        delay = queue_config.retry_delay_proc.call(retry_delay, num_retries) rescue retry_delay
         job.retry(num_retries + 1, delay)
         self.log_job_end(job.name, "#{retry_status}, retrying in #{delay}s") if job_started_at
       else # retries failed, bury

--- a/lib/backburner/worker.rb
+++ b/lib/backburner/worker.rb
@@ -150,10 +150,11 @@ module Backburner
       # NB: There's a slight chance here that the connection to beanstalkd has
       # gone down between the time we reserved / processed the job and here.
       num_retries = job.stats.releases
-      retry_status = "failed: attempt #{num_retries+1} of #{queue_config.max_job_retries+1}"
-      if num_retries < queue_config.max_job_retries # retry again
+      max_job_retries = resolve_max_job_retries(job.job_class)
+      retry_status = "failed: attempt #{num_retries+1} of #{max_job_retries+1}"
+      if num_retries < max_job_retries # retry again
         retry_delay = resolve_retry_delay(job.job_class)
-        delay = queue_config.retry_delay_proc.call(retry_delay, num_retries) rescue retry_delay
+        delay = resolve_retry_delay_proc(job.job_class).call(retry_delay, num_retries) rescue retry_delay
         job.retry(num_retries + 1, delay)
         self.log_job_end(job.name, "#{retry_status}, retrying in #{delay}s") if job_started_at
       else # retries failed, bury

--- a/test/fixtures/test_jobs.rb
+++ b/test/fixtures/test_jobs.rb
@@ -54,6 +54,27 @@ class TestConfigurableRetryJob
   end
 end
 
+class TestRetryWithQueueOverridesJob
+  include Backburner::Queue
+  def self.perform(retry_count)
+    $worker_test_count += 1
+    raise RuntimeError unless $worker_test_count > retry_count
+    $worker_success = true
+  end
+
+  def self.queue_max_job_retries
+    3
+  end
+
+  def self.queue_retry_delay
+    0
+  end
+
+  def self.queue_retry_delay_proc
+    lambda { |min_retry_delay, num_retries| min_retry_delay + (num_retries ** 2) }
+  end
+end
+
 class TestAsyncJob
   include Backburner::Performable
   def self.foo(x, y); $worker_test_count = x * y; end

--- a/test/helpers_test.rb
+++ b/test/helpers_test.rb
@@ -179,4 +179,35 @@ describe "Backburner::Helpers module" do
       assert_equal 300, resolve_respond_timeout(nil)
     end
   end # resolve_respond_timeout
+
+  describe "for resolve_retry_delay method" do
+    before do
+      @original_retry_delay = Backburner.configuration.retry_delay
+      Backburner.configure { |config| config.retry_delay = 300 }
+    end
+    after { Backburner.configure { |config| config.retry_delay = @original_retry_delay } }
+
+    it "supports fix num retry_delay" do
+      assert_equal 500, resolve_retry_delay(500)
+    end
+
+    it "supports classes which respond to queue_retry_delay" do
+      job = stub(:queue_retry_delay => 600)
+      assert_equal 600, resolve_retry_delay(job)
+    end
+
+    it "supports classes which returns null queue_retry_delay" do
+      job = stub(:queue_retry_delay => nil)
+      assert_equal 300, resolve_retry_delay(job)
+    end
+
+    it "supports classes which don't respond to queue_retry_delay" do
+      job = stub(:fake => true)
+      assert_equal 300, resolve_retry_delay(job)
+    end
+
+    it "supports default ttr for null values" do
+      assert_equal 300, resolve_retry_delay(nil)
+    end
+  end # resolve_retry_delay
 end

--- a/test/queue_test.rb
+++ b/test/queue_test.rb
@@ -45,10 +45,25 @@ describe "Backburner::Queue module" do
     end
   end # queue_respond_timeout
 
+  describe "for queue_max_job_retries assignment method" do
+    it "should allow queue max_job_retries to be assigned" do
+      NestedDemo::TestJobB.queue_max_job_retries(5)
+      assert_equal 5, NestedDemo::TestJobB.queue_max_job_retries
+    end
+  end # queue_max_job_retries
+
   describe "for queue_retry_delay assignment method" do
     it "should allow queue retry_delay to be assigned" do
       NestedDemo::TestJobB.queue_retry_delay(300)
       assert_equal 300, NestedDemo::TestJobB.queue_retry_delay
     end
   end # queue_retry_delay
+
+  describe "for queue_retry_delay_proc assignment method" do
+    it "should allow queue retry_delay_proc to be assigned" do
+      retry_delay_proc = lambda { |x, y| x - y }
+      NestedDemo::TestJobB.queue_retry_delay_proc(retry_delay_proc)
+      assert_equal retry_delay_proc.call(2, 1), NestedDemo::TestJobB.queue_retry_delay_proc.call(2, 1)
+    end
+  end # queue_retry_delay_proc
 end # Backburner::Queue

--- a/test/queue_test.rb
+++ b/test/queue_test.rb
@@ -44,4 +44,11 @@ describe "Backburner::Queue module" do
       assert_equal 300, NestedDemo::TestJobB.queue_respond_timeout
     end
   end # queue_respond_timeout
+
+  describe "for queue_retry_delay assignment method" do
+    it "should allow queue retry_delay to be assigned" do
+      NestedDemo::TestJobB.queue_retry_delay(300)
+      assert_equal 300, NestedDemo::TestJobB.queue_retry_delay
+    end
+  end # queue_retry_delay
 end # Backburner::Queue


### PR DESCRIPTION
See #57 for background discussion.

This allows per queue overrides of the following settings.
- max_job_retries
- retry_delay
- retry_delay_proc

Examples are in the README.

I've only been able to test this with the `Simple` worker but the changes should apply to all workers.