### PR TITLE
Allow jobs touching

### DIFF
--- a/HOOKS.md
+++ b/HOOKS.md
@@ -33,6 +33,8 @@ There are a variety of hooks available that are triggered during the lifecycle o
 * `on_failure`: Called with the exception and job args if any exception occurs
   while performing the job (or hooks).
 
+* `on_touch`: Called with the job args when the job is touched.
+
 Hooks are just methods prefixed with the hook type. For example:
 
 ```ruby

--- a/lib/backburner/job.rb
+++ b/lib/backburner/job.rb
@@ -53,7 +53,7 @@ module Backburner
         #  b) ttr == 1, so that we don't accidentally set it to never time out
         #  NB: A ttr of 1 will likely result in race conditions between
         #  Backburner and beanstalkd and should probably be avoided
-        timeout_job_after(task.ttr > 1 ? task.ttr - 1 : task.ttr) { job_class.perform(*args) }
+        start_job { job_class.perform(*args) }
       end
       task.delete
       # Invoke after perform hook
@@ -71,6 +71,11 @@ module Backburner
     def retry(count, delay)
       @hooks.invoke_hook_events(job_name, :on_retry, count, delay, *args)
       task.release(delay: delay)
+    end
+
+    def touch
+      @hooks.invoke_hook_events(job_name, :on_touch, *args)
+      task.touch
     end
 
     protected
@@ -101,16 +106,43 @@ module Backburner
       nil
     end
 
-    # Timeout job within specified block after given time.
+    # Start the specified block.
     #
     # @example
-    #   timeout_job_after(3) { do_something! }
+    #   start_job { do_something! }
     #
-    def timeout_job_after(secs, &block)
-      begin
-        Timeout::timeout(secs) { yield }
-      rescue Timeout::Error => e
-        raise JobTimeout, "#{name}(#{(@args||[]).join(', ')}) hit #{secs}s timeout.\nbacktrace: #{e.backtrace}"
+    def start_job(&block)
+      return yield if task.stats.ttr == 0
+
+      current_thread = Thread.current
+      block_thread = Thread.start do
+        begin
+          yield
+        rescue JobTimeout => e
+          current_thread.raise JobTimeout, "#{name}(#{(@args||[]).join(', ')}) hit #{task.stats.ttr}s timeout.\nbacktrace: #{e.backtrace}"
+        rescue => e
+          current_thread.raise e
+        end
+      end
+      job_timer(block_thread)
+      block_thread.join
+    end
+
+    # Start a thread burying the job and raising an error if the job has timed out
+    #
+    # @example
+    #   job_timer(thread)
+    #
+    def job_timer(watched_thread)
+      Thread.start do
+        while(task.stats.time_left > 0) do
+          sleep(task.stats.time_left)
+        end
+
+        if watched_thread.alive?
+          task.bury
+          watched_thread.raise JobTimeout.new
+        end
       end
     end
 

--- a/lib/backburner/worker.rb
+++ b/lib/backburner/worker.rb
@@ -156,7 +156,7 @@ module Backburner
         job.retry(num_retries + 1, delay)
         self.log_job_end(job.name, "#{retry_status}, retrying in #{delay}s") if job_started_at
       else # retries failed, bury
-        job.bury
+        job.bury if job.stats.state != "buried"
         self.log_job_end(job.name, "#{retry_status}, burying") if job_started_at
       end
 

--- a/test/hooks_test.rb
+++ b/test/hooks_test.rb
@@ -84,6 +84,13 @@ describe "Backburner::Hooks module" do
       end
     end
 
+    describe 'with on_touch' do
+      it "should support successful invocation" do
+        out = silenced { @hooks.invoke_hook_events(HookedObjectSuccess, :on_touch, 10) }
+        assert_match(/!!on_touch_foo!! \[10\]/, out)
+      end
+    end
+
     describe "with on_reconnect" do
       it "should support successful invocation" do
         out = silenced { @hooks.invoke_hook_events(HookedWorker.new, :on_reconnect)}

--- a/test/job_test.rb
+++ b/test/job_test.rb
@@ -147,6 +147,14 @@ describe "Backburner::Job module" do
           .with("AnUnknownClass", :on_retry, 0, is_a(Integer), anything)
         @job.retry(0, 0)
       end
+
+      it "should call touch for task" do
+        @task.expects(:touch).once
+        @job = Backburner::Job.new(@task)
+        Backburner::Hooks.expects(:invoke_hook_events)
+          .with("AnUnknownClass", :on_touch, anything)
+        @job.touch
+      end
     end
   end # simple delegation
 


### PR DESCRIPTION
We have long running jobs and need to be able to touch them.
I tried something with a thread checking if the job is timed out and not using a timeout with the default ttr.

I just can't understand why I need to manually bury the job after it timed out or the bury in  `worber.rb:work_one_job` throws me a NOT_FOUND error.