### PR TITLE
Correctly remove the buildin rails adapter

### DIFF
--- a/lib/active_job/queue_adapters/backburner_adapter.rb
+++ b/lib/active_job/queue_adapters/backburner_adapter.rb
@@ -1,7 +1,7 @@
 module ActiveJob
   module QueueAdapters
     # Explicitly remove the implementation existing in older rails'.
-    remove_const(:BackburnerAdapter) if defined?(:BackburnerAdapter)
+    remove_const(:BackburnerAdapter) if const_defined?(:BackburnerAdapter)
 
     # = Backburner adapter for Active Job
     #


### PR DESCRIPTION
Followup to #180

`defined?` for a symbol literal is always truthy. `defined?(ActiveJob::QueueAdapters::BackburnerAdapter)` would also work as an alternative.

```rb
module ActiveJob
  module QueueAdapters
    # Adapter removed from rails
  end
end

module ActiveJob
  module QueueAdapters
    remove_const(:BackburnerAdapter) if defined?(:BackburnerAdapter)
  end
end
```

`test.rb:10:in 'remove_const': constant ActiveJob::QueueAdapters::BackburnerAdapter not defined (NameError)`